### PR TITLE
chore, refactor(app): remove type aliases

### DIFF
--- a/src/app/features/app/app.component.spec.ts
+++ b/src/app/features/app/app.component.spec.ts
@@ -4,8 +4,8 @@ import { createComponentFactory, Spectator } from '@ngneat/spectator';
 import { MockComponent } from 'ng-mocks';
 
 import { AppComponent } from './app.component';
-import { FooterComponent } from '@shared/components/footer/footer.component';
-import { NavComponent } from '@shared/components/nav/nav.component';
+import { FooterComponent } from 'app/infrastructure/shared/components/footer/footer.component';
+import { NavComponent } from 'app/infrastructure/shared/components/nav/nav.component';
 
 describe('[Integration] AppComponent', () => {
   let spectator: Spectator<AppComponent>;

--- a/src/app/features/app/app.module.ts
+++ b/src/app/features/app/app.module.ts
@@ -8,7 +8,7 @@ import {
 } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { SandboxModule } from '../sandbox/sandbox.module';
-import { SharedModule } from '@shared/shared.module';
+import { SharedModule } from 'app/infrastructure/shared/shared.module';
 
 @NgModule({
   declarations: [AppComponent, mainComponents],

--- a/src/app/features/sandbox/sandbox.module.ts
+++ b/src/app/features/sandbox/sandbox.module.ts
@@ -4,7 +4,7 @@ import {
   SandboxRoutingModule,
   components as sandboxComponents,
 } from './sandbox-routing.module';
-import { SharedModule } from '@shared/shared.module';
+import { SharedModule } from 'app/infrastructure/shared/shared.module';
 
 /**
  * Feature module for all sandbox-related components and dependencies.

--- a/src/app/features/sandbox/test/test.component.spec.ts
+++ b/src/app/features/sandbox/test/test.component.spec.ts
@@ -3,7 +3,7 @@ import { MatCardModule } from '@angular/material/card';
 import { createComponentFactory, Spectator } from '@ngneat/spectator';
 import { MockModule, MockPipe } from 'ng-mocks';
 
-import { LocaleUpperCasePipe } from '@shared/pipes/locale-upper-case.pipe';
+import { LocaleUpperCasePipe } from 'app/infrastructure/shared/pipes/locale-upper-case.pipe';
 import { TestComponent } from './test.component';
 
 describe('[Integration] TestComponent', () => {

--- a/src/app/infrastructure/shared/components/footer/footer.component.ts
+++ b/src/app/infrastructure/shared/components/footer/footer.component.ts
@@ -1,7 +1,7 @@
 import { Component, ChangeDetectionStrategy } from '@angular/core';
 
-import { environment } from '@env/environment';
-import { Utils } from '@utils/utils';
+import { environment } from 'environments/environment';
+import { Utils } from 'app/infrastructure/utils/utils';
 
 @Component({
   selector: 'app-footer',

--- a/src/app/infrastructure/shared/components/nav/nav.component.spec.ts
+++ b/src/app/infrastructure/shared/components/nav/nav.component.spec.ts
@@ -1,7 +1,7 @@
 import { createComponentFactory, Spectator } from '@ngneat/spectator';
 import { MockPipe } from 'ng-mocks';
 
-import { LocaleUpperCasePipe } from '@shared/pipes/locale-upper-case.pipe';
+import { LocaleUpperCasePipe } from 'app/infrastructure/shared/pipes/locale-upper-case.pipe';
 import { NavComponent } from './nav.component';
 
 describe('[Integration] NavComponent', () => {

--- a/src/app/infrastructure/shared/pipes/locale-upper-case.pipe.spec.ts
+++ b/src/app/infrastructure/shared/pipes/locale-upper-case.pipe.spec.ts
@@ -1,4 +1,4 @@
-import { Constants } from '@app/infrastructure/utils/constants';
+import { Constants } from 'app/infrastructure/utils/constants';
 
 import { LocaleUpperCasePipe } from './locale-upper-case.pipe';
 

--- a/src/app/infrastructure/shared/pipes/locale-upper-case.pipe.ts
+++ b/src/app/infrastructure/shared/pipes/locale-upper-case.pipe.ts
@@ -1,6 +1,6 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
-import { Constants } from '@utils/constants';
+import { Constants } from 'app/infrastructure/utils/constants';
 
 @Pipe({ name: 'localeuppercase' })
 export class LocaleUpperCasePipe implements PipeTransform {

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@ import { enableProdMode } from '@angular/core';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 
 import { AppModule } from './app/features/app/app.module';
-import { environment } from '@env/environment';
+import { environment } from 'environments/environment';
 
 if (environment.production) {
   enableProdMode();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,30 +20,6 @@
       "es2018",
       "dom"
     ],
-    "paths": {
-      "@app/*": [
-        "app/*"
-      ],
-      "@assets/*": ["assets/*"],
-      "@core/*": [
-        "app/infrastructure/core/*"
-      ],
-      "@env/*": [
-        "environments/*"
-      ],
-      "@features/*": [
-        "app/features/*"
-      ],
-      "@models/*": [
-        "app/infrastructure/models/*"
-      ],
-      "@shared/*": [
-        "app/infrastructure/shared/*"
-      ],
-      "@utils/*": [
-        "app/infrastructure/utils/*"
-      ]
-    },
     "resolveJsonModule": true
   },
   "angularCompilerOptions": {


### PR DESCRIPTION
## Changes

StackBlitz cannot currently parse path aliases. I want to share this repository through StackBlitz, so I will undo the aliases.

- [x] Replace path aliases with relative paths.

Closes #19.